### PR TITLE
Redesign - from floating windows to split windows

### DIFF
--- a/lua/undodiff/init.lua
+++ b/lua/undodiff/init.lua
@@ -8,50 +8,56 @@ function M.setup(_opts)
 end
 
 function M.attach()
-	local old_buf = vim.api.nvim_get_current_buf()
+	local curr_buf = vim.api.nvim_get_current_buf()
 
-	-- if already open, close
-	if state.is_active(old_buf) then
+	if state.is_active(curr_buf) then
 		state.clear(state.buffers, state.scratch_win)
-		require("undotree").open()
 		return
 	end
 
-	-- save the state of file buffer
-	local ft = vim.bo[old_buf].filetype
-	local old_lines = vim.api.nvim_buf_get_lines(old_buf, 0, -1, false)
+	local ft = vim.bo[curr_buf].filetype
+	local old_lines = vim.api.nvim_buf_get_lines(curr_buf, 0, -1, false)
 	local old_win = vim.api.nvim_get_current_win()
 
-	-- open undotree
 	vim.cmd("packadd nvim.undotree")
 	local tree_buf = vim.api.nvim_create_buf(false, true)
 	vim.bo[tree_buf].bufhidden = "wipe"
 	require("undotree").open({ bufnr = tree_buf })
 	local tree_win = vim.api.nvim_get_current_win()
 
-	-- split the file windowto old_win & new_win
 	vim.api.nvim_set_current_win(old_win)
 	vim.cmd("vsplit")
 	local new_win = vim.api.nvim_get_current_win()
 	local new_buf = vim.api.nvim_create_buf(false, true)
 
-	-- save in state for cleanup
-	state.buffers = { old_buf, tree_buf, new_buf }
+	local old_buf = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_buf_set_lines(old_buf, 0, -1, false, old_lines)
+
+	state.buffers = { tree_buf, new_buf, old_buf }
 	state.scratch_win = new_win
+	state.tree_win = tree_win
+	state.old_win = old_win
+	state.curr_buf = curr_buf
 	state.set_active(state.buffers)
 
-	-- prep for diffview
 	vim.bo[new_buf].filetype = ft
+	vim.bo[old_buf].filetype = ft
 	vim.wo[old_win].scrollbind = true
 	vim.wo[new_win].scrollbind = true
 
-	-- render diff
 	require("codediff").setup({})
-	require("undodiff.render").setup(tree_buf, old_buf, new_buf, old_lines)
+	require("undodiff.render").setup(tree_buf, curr_buf, old_buf, new_buf, old_lines)
 	vim.api.nvim_win_set_buf(old_win, old_buf)
 	vim.api.nvim_win_set_buf(new_win, new_buf)
 
-	-- focus back to undodiff split
+	vim.api.nvim_create_autocmd("WinClosed", {
+		pattern = tostring(tree_win),
+		once = true,
+		callback = function()
+			state.clear(state.buffers, state.scratch_win)
+		end,
+	})
+
 	vim.api.nvim_set_current_win(tree_win)
 end
 

--- a/lua/undodiff/render.lua
+++ b/lua/undodiff/render.lua
@@ -1,15 +1,14 @@
 local M = {}
 
-function M.setup(tree_buf, old_buf, new_buf, old_lines)
+function M.setup(tree_buf, curr_buf, old_buf, new_buf, old_lines)
 	local diff = require("codediff.core.diff")
 	local core = require("codediff.ui.core")
 
 	vim.api.nvim_create_autocmd("CursorMoved", {
 		buffer = tree_buf,
 		callback = function()
-			local new_lines = vim.api.nvim_buf_get_lines(old_buf, 0, -1, false)
+			local new_lines = vim.api.nvim_buf_get_lines(curr_buf, 0, -1, false)
 			vim.bo[new_buf].modifiable = true
-			vim.api.nvim_buf_set_lines(old_buf, 0, -1, false, old_lines)
 			vim.api.nvim_buf_set_lines(new_buf, 0, -1, false, new_lines)
 			core.render_diff(old_buf, new_buf, old_lines, new_lines, diff.compute_diff(old_lines, new_lines))
 			vim.bo[new_buf].modifiable = false

--- a/lua/undodiff/state.lua
+++ b/lua/undodiff/state.lua
@@ -11,11 +11,20 @@ function M.set_active(buffers)
 end
 
 function M.clear(buffers, scratch_win)
+	if M.old_win and vim.api.nvim_win_is_valid(M.old_win) and M.curr_buf then
+		vim.api.nvim_win_set_buf(M.old_win, M.curr_buf)
+		M.old_win = nil
+		M.curr_buf = nil
+	end
 	for _, bufnr in ipairs(buffers) do
 		vim.b[bufnr].undodiff_active = nil
 	end
 	if scratch_win and vim.api.nvim_win_is_valid(scratch_win) then
 		vim.api.nvim_win_close(scratch_win, true)
+	end
+	if M.tree_win and vim.api.nvim_win_is_valid(M.tree_win) then
+		vim.api.nvim_win_close(M.tree_win, true)
+		M.tree_win = nil
 	end
 end
 


### PR DESCRIPTION
- Redesigned the diffview so that they are split windows instead of floating windows. Main reasoning was to support split window jumps with ctrl + w.
- refactored clean up logic.
- UndoDiff command is now a toggle.
- Closing undotree pane closes the scratch buffers as well.